### PR TITLE
improve drop.extinct

### DIFF
--- a/man/drop.extinct.Rd
+++ b/man/drop.extinct.Rd
@@ -6,7 +6,7 @@
   pruning a set of taxa from a tree
 }
 \usage{
-drop.extinct(phy, tol = NULL) 
+drop.extinct(phy, tol = .Machine$double.eps^0.5) 
 drop.random(phy, n)
 
 }
@@ -18,7 +18,7 @@ drop.random(phy, n)
 }
 
 \details{
-The functions prune taxa from a tree either at random or based either on a temporal criterion (whether the leaves reach the present within a given \code{tol}). By default, \code{tol = min(phy$edge.length)/100}. The result is a tree that has been pruned based on the given criterion.}
+The functions prune taxa from a tree either at random or based either on a temporal criterion (whether the leaves reach the present within a given \code{tol}). By default, \code{tol = tol=.Machine$double.eps^0.5}. The result is a tree that has been pruned based on the given criterion.}
 
 	
 \author{ LJ Harmon }


### PR DESCRIPTION
`drop.extinct` is prohibitively slow. For a [simulated tree](https://www.dropbox.com/s/njlmg3hbw2739no/p4.tre?dl=0), pruning extinct taxa takes a crazily long amount of time:

``` R
system.time(p5 <- drop.extinct(p4))
    user   system  elapsed 
1969.877   12.600 1984.587
```

The new function (borrowing liberally from the ape function `is.ultrametric`) takes significantly less time:

``` R
system.time(p6 <- drop.extinct2(p4))
   user  system elapsed 
 34.907   1.358  36.268 
```

This gives identical results:

``` R
all.equal(p5, p6);
[1] TRUE
```

Furthermore, the overwhelming bulk of the the time spent in the new function is taken up by the requisite ape function `collapse.singles` (essentially 99% of the time reported above). I am looking into this function, but the increase in efficiency already achieved above makes this code change a significant improvement.

Pretty straight-forward upgrade, but I thought I would submit it via the pull-request route to encourage explicit vetting. [Inspired also by the OpenTree workflow, where changes must be explicitly approved by someone that is not an immediate contributor. This workflow can be frustratingly slow at times (i.e. getting someone to approve code changes), but probably a good strategy].

So, yeah: aimed at you @mwpennell (or whoever is paying attention).
