### PR TITLE
Fixes for non-ultrametric trees

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,32 @@
-language: c
-
-env:
-  - global:
-    - WARNINGS_ARE_ERRORS=1
+language: r
+cache: packages
+warnings_are_errors: TRUE
 
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - ./travis-tool.sh install_deps
-script: ./travis-tool.sh run_tests
+- sudo apt-get install libgmp3-dev
+- export RGL_USE_NULL=TRUE 
 
-on_failure:
-  - ./travis-tool.sh dump_logs
-after_failure:
-  "cat /home/travis/build/mwpennell/geiger-v2/geiger.Rcheck/00install.out"
+script:
+- R CMD build .
+- travis_wait 45 R CMD check *tar.gz --as-cran
+  
+#after_success:
+#  - Rscript -e 'covr::codecov()'
 
-notifications:
-  email:
-    on_success: change
-    on_failure: change
+  
+#before_install:
+#  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+#  - chmod 755 ./travis-tool.sh
+#  - ./travis-tool.sh bootstrap
+#install:
+#  - ./travis-tool.sh install_deps
+#script: ./travis-tool.sh run_tests
+#on_failure:
+#  - ./travis-tool.sh dump_logs
+#after_failure:
+ # "cat /home/travis/build/mwpennell/geiger-v2/geiger.Rcheck/00install.out"
+#
+#notifications:
+#  email:
+#    on_success: change
+#    on_failure: change

--- a/R/diversitree.R
+++ b/R/diversitree.R
@@ -13,7 +13,6 @@
   tip=tip[tip%in%c(1:Ntip)]
   if(!length(tip)) return(phy)
 
-
   phy <- reorder(phy)
   NEWROOT <- ROOT <- Ntip + 1
   Nnode <- phy$Nnode

--- a/R/mecca.R
+++ b/R/mecca.R
@@ -163,7 +163,7 @@ sim.mecca <-
 #MECCAsim <-
 function(phy, richness, cladeAges, model, prop, makeNewTipTrees = TRUE, mytiptrees = NULL, hotBranches = NULL) {
 
-	root.age = max(branching.times(phy));
+	root.age = max(node.depth.edgelength(phy));
 
 	if(makeNewTipTrees == FALSE & is.null(mytiptrees)) stop("there are no tip trees provided");
 	cladeAncStates <- .mecca.nodesim(phy, model, prop, hotBranches);
@@ -910,7 +910,7 @@ function(phy, model, cladeAges, treelist, prop, hotBranches = NULL, richness=ric
 	Smean	<- numeric(length(treelist))
 	Svar <- numeric(length(treelist))
 
-    root.age <- max(branching.times(phy));
+    root.age <- max(node.depth.edgelength(phy));
 	cladeAncStates <- .mecca.nodesim(phy, model, prop, hotBranches);
 
 	for(i in 1:length(treelist)) {

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -659,7 +659,7 @@ bg = "lightgreen", horiz = FALSE, width = NULL, height = NULL,
 	pp=pretty(c(0,max(hist$time)))
 	plot(x=NULL, y=NULL, xlim=rev(range(pp)), ylim=range(pretty(c(-mm+alpha, mm+alpha))), bty="n", xlab="time", ylab="phenotypic value")
 	hist$ptime=abs(hist$time-max(hist$time))
-	mbt=max(branching.times(phy))
+	mbt=max(node.depth.edgelength(phy))
 	for(i in 1:nrow(hist)) {
 		start=ifelse(hist$ancestor[i]==root, alpha, hist$phenotype[which(hist$descendant==hist$ancestor[i])])
 		stime=ifelse(hist$ancestor[i]==root, mbt, hist$ptime[which(hist$descendant==hist$ancestor[i])])

--- a/R/traits.R
+++ b/R/traits.R
@@ -64,7 +64,7 @@ ncores=NULL, ...
 	argn=argn(lik)
 
     ## CONSTRUCT BOUNDS ##
-	mn=c(-500, -500, (log(10^(-5))/max(branching.times(phy))), -100, -100, -500, -500, -500, -500)
+	mn=c(-500, -500, (log(10^(-5))/max(node.depth.edgelength(phy))), -100, -100, -500, -500, -500, -500)
 	mx=c(100, 1, -0.000001, 100, 100, 0, 0, log(2.999999), 100)
 	bnds=as.data.frame(cbind(mn, mx))
 	bnds$typ=c("exp", "exp", "nat", "nat", "nat", "exp", "exp", "exp", "exp")

--- a/man/r8s.phylo.Rd
+++ b/man/r8s.phylo.Rd
@@ -9,7 +9,7 @@ call r8s from geiger}
 \description{
 call r8s, including a calibration file}
 \usage{
-r8s.phylophy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,  blformat=c(lengths="persite", nsites=1e5, ultrametric="no", round="yes"), divtime=c(method="NPRS", algorithm="POWELL"), cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
+r8s.phylo(phy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,  blformat=c(lengths="persite", nsites=1e5, ultrametric="no", round="yes"), divtime=c(method="NPRS", algorithm="POWELL"), cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -33,7 +33,18 @@ SANDERSON r8s ____NEED TO ADD_____
 \author{JM Eastman & B O'Meara}
 
 \examples{
-	phy <- read.tree(text="(Marchantia:0.033817,(Lycopodium:0.040281,((Equisetum:0.048533,(Osmunda:0.033640,Asplenium:0.036526):0.000425):0.011806,((((Cycas:0.009460,Zamia:0.018847):0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:0.021500,(Podocarpac:0.015649,Taxus:0.021081):0.006473):0.002448,(Ephedra:0.029965,(Welwitsch:0.011298,Gnetum:0.014165):0.006883):0.016663):0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:0.019902,Chloranth:0.020151):1.687e-86,((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):0.002933):0.007654,Acorus:0.038488):0.007844):1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):0.004656):1.687e-86,((Magnolia:0.015119,Drimys:0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:0.006180,Platanus:0.002347):0.003958,(Buxaceae:0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:0.008236):0.001459):0.001994,(Ericaceae:0.019136,Solanaceae:0.041396):0.002619):1.687e-86):0.004803):1.687e-86):0.006457):0.002918):0.007348,Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:0.019263):0.003527):0.021625):0.012469):0.019372);")
+	phy <- read.tree(text=paste0("(Marchantia:0.033817,(Lycopodium:0.040281,((Equisetum:0.048533,(",
+		"Osmunda:0.033640,Asplenium:0.036526):0.000425):0.011806,((((Cycas:0.009460,Zamia:0.018847):",
+		"0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:0.021500,(Podocarpac:0.015649,Taxus:0.021081):",
+		"0.006473):0.002448,(Ephedra:0.029965,(Welwitsch:0.011298,Gnetum:0.014165):0.006883):0.016663)",
+		":0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:0.019902,Chloranth:0.020151):1.687e-86,",
+		"((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):0.002933):0.007654,Acorus:0.038488):0.007844)",
+		":1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):0.004656):1.687e-86,((Magnolia:0.015119,Drimys:",
+		"0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:0.006180,Platanus:0.002347):0.003958,(Buxaceae:",
+		"0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:0.008236):0.001459):0.001994,(Ericaceae:0.019136,",
+		"Solanaceae:0.041396):0.002619):1.687e-86):0.004803):1.687e-86):0.006457):0.002918):0.007348,",
+		"Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:0.019263):0.003527):0.021625):0.012469):0.019372);"))
+		
 	calibrations <- data.frame(MRCA="LP", MaxAge=450, MinAge=450, taxonA="marchantia", taxonB="pisum", stringsAsFactors=FALSE)
 	\dontrun{
 	phy.nprs <- r8s.phylo(phy=phy, calibrations=calibrations, base="nprs_file", ez.run="NPRS")

--- a/man/r8s.phylo.Rd
+++ b/man/r8s.phylo.Rd
@@ -9,7 +9,7 @@ call r8s from geiger}
 \description{
 call r8s, including a calibration file}
 \usage{
-r8s.phylo(phy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,  blformat=c(lengths="persite", nsites=1e5, ultrametric="no", round="yes"), divtime=c(method="NPRS", algorithm="POWELL"), cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
+r8s.phylo(phy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,  blformat=c(lengths="persite", nsites=10000, ultrametric="no", round="yes"), divtime=c(method="NPRS", algorithm="POWELL"), cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -34,17 +34,28 @@ SANDERSON r8s ____NEED TO ADD_____
 
 \examples{
 
-phy <- read.tree(text=paste0("(Marchantia:0.033817,(Lycopodium:0.040281,((Equisetum:0.048533",
-  "Osmunda:0.033640,Asplenium:0.036526):0.000425):0.011806,((((Cycas:0.009460,Zamia:0.018847):",
-  "0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:0.021500,(Podocarpac:0.015649,Taxus:0.021081):",
-  "0.006473):0.002448,(Ephedra:0.029965,(Welwitsch:0.011298,Gnetum:0.014165):0.006883):0.016663)",
-  ":0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:0.019902,Chloranth:0.020151):1.687e-86,",
-  "((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):0.002933):0.007654,Acorus:0.038488):0.007844)",
-  ":1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):0.004656):1.687e-86,((Magnolia:0.015119,Drimys:",
-  "0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:0.006180,Platanus:0.002347):0.003958,(Buxaceae:",
-  "0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:0.008236):0.001459):0.001994,(Ericaceae:0.019136,",
-  "Solanaceae:0.041396):0.002619):1.687e-86):0.004803):1.687e-86):0.006457):0.002918):0.007348,",
-  "Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:0.019263):0.003527):0.021625):0.012469):",
+phy <- read.tree(text=paste0("(Marchantia:0.033817,",
+  "(Lycopodium:0.040281,((Equisetum:0.048533",
+  "Osmunda:0.033640,Asplenium:0.036526):0.000425):",
+  "0.011806,((((Cycas:0.009460,Zamia:0.018847):",
+  "0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:",
+  "0.021500,(Podocarpac:0.015649,Taxus:0.021081):",
+  "0.006473):0.002448,(Ephedra:0.029965,(Welwitsch",
+  ":0.011298,Gnetum:0.014165):0.006883):0.016663)",
+  ":0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:",
+  "0.019902,Chloranth:0.020151):1.687e-86,",
+  "((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):",
+  "0.002933):0.007654,Acorus:0.038488):0.007844)",
+  ":1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):",
+  "0.004656):1.687e-86,((Magnolia:0.015119,Drimys:",
+  "0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:",
+  "0.006180,Platanus:0.002347):0.003958,(Buxaceae:",
+  "0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:",
+  "0.008236):0.001459):0.001994,(Ericaceae:0.019136,",
+  "Solanaceae:0.041396):0.002619):1.687e-86):0.004803)",
+  ":1.687e-86):0.006457):0.002918):0.007348,",
+  "Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:",
+  "0.019263):0.003527):0.021625):0.012469):",
   "0.019372);"))
   	
 	calibrations <- data.frame(MRCA="LP", MaxAge=450, MinAge=450, taxonA="marchantia", taxonB="pisum", stringsAsFactors=FALSE)

--- a/man/r8s.phylo.Rd
+++ b/man/r8s.phylo.Rd
@@ -9,7 +9,10 @@ call r8s from geiger}
 \description{
 call r8s, including a calibration file}
 \usage{
-r8s.phylo(phy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,  blformat=c(lengths="persite", nsites=10000, ultrametric="no", round="yes"), divtime=c(method="NPRS", algorithm="POWELL"), cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
+r8s.phylo(phy, calibrations=NULL, base="r8srun", ez.run="none", rm=TRUE,
+  blformat=c(lengths="persite", nsites=10000, ultrametric="no", round="yes"),
+  divtime=c(method="NPRS", algorithm="POWELL"),
+  cv=c(cvStart=0, cvInc=0.5, cvNum=8), do.cv=FALSE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -58,7 +61,8 @@ phy <- read.tree(text=paste0("(Marchantia:0.033817,",
   "0.019263):0.003527):0.021625):0.012469):",
   "0.019372);"))
   	
-	calibrations <- data.frame(MRCA="LP", MaxAge=450, MinAge=450, taxonA="marchantia", taxonB="pisum", stringsAsFactors=FALSE)
+	calibrations <- data.frame(MRCA="LP", MaxAge=450, MinAge=450,
+		taxonA="marchantia", taxonB="pisum", stringsAsFactors=FALSE)
 	\dontrun{
 	phy.nprs <- r8s.phylo(phy=phy, calibrations=calibrations, base="nprs_file", ez.run="NPRS")
 	phy.pl <- r8s.phylo(phy=phy, calibrations=calibrations, base="pl_file", ez.run="PL")

--- a/man/r8s.phylo.Rd
+++ b/man/r8s.phylo.Rd
@@ -33,18 +33,20 @@ SANDERSON r8s ____NEED TO ADD_____
 \author{JM Eastman & B O'Meara}
 
 \examples{
-	phy <- read.tree(text=paste0("(Marchantia:0.033817,(Lycopodium:0.040281,((Equisetum:0.048533,(",
-		"Osmunda:0.033640,Asplenium:0.036526):0.000425):0.011806,((((Cycas:0.009460,Zamia:0.018847):",
-		"0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:0.021500,(Podocarpac:0.015649,Taxus:0.021081):",
-		"0.006473):0.002448,(Ephedra:0.029965,(Welwitsch:0.011298,Gnetum:0.014165):0.006883):0.016663)",
-		":0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:0.019902,Chloranth:0.020151):1.687e-86,",
-		"((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):0.002933):0.007654,Acorus:0.038488):0.007844)",
-		":1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):0.004656):1.687e-86,((Magnolia:0.015119,Drimys:",
-		"0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:0.006180,Platanus:0.002347):0.003958,(Buxaceae:",
-		"0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:0.008236):0.001459):0.001994,(Ericaceae:0.019136,",
-		"Solanaceae:0.041396):0.002619):1.687e-86):0.004803):1.687e-86):0.006457):0.002918):0.007348,",
-		"Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:0.019263):0.003527):0.021625):0.012469):0.019372);"))
-		
+
+phy <- read.tree(text=paste0("(Marchantia:0.033817,(Lycopodium:0.040281,((Equisetum:0.048533",
+  "Osmunda:0.033640,Asplenium:0.036526):0.000425):0.011806,((((Cycas:0.009460,Zamia:0.018847):",
+  "0.005021,Ginkgo:0.014702):1.687e-86,((Pinus:0.021500,(Podocarpac:0.015649,Taxus:0.021081):",
+  "0.006473):0.002448,(Ephedra:0.029965,(Welwitsch:0.011298,Gnetum:0.014165):0.006883):0.016663)",
+  ":0.006309):0.010855,((Nymphaea:0.016835,(((((Saururus:0.019902,Chloranth:0.020151):1.687e-86,",
+  "((Araceae:0.020003,(Palmae:0.006005,Oryza:0.031555):0.002933):0.007654,Acorus:0.038488):0.007844)",
+  ":1.777e-83,(Calycanth:0.013524,Lauraceae:0.035902):0.004656):1.687e-86,((Magnolia:0.015119,Drimys:",
+  "0.010172):0.005117,(Ranunculus:0.029027,((Nelumbo:0.006180,Platanus:0.002347):0.003958,(Buxaceae:",
+  "0.013294,((Pisum:0.035675,(Fagus:0.009848,Carya:0.008236):0.001459):0.001994,(Ericaceae:0.019136,",
+  "Solanaceae:0.041396):0.002619):1.687e-86):0.004803):1.687e-86):0.006457):0.002918):0.007348,",
+  "Austrobail:0.019265):1.687e-86):1.687e-86,Amborella:0.019263):0.003527):0.021625):0.012469):",
+  "0.019372);"))
+  	
 	calibrations <- data.frame(MRCA="LP", MaxAge=450, MinAge=450, taxonA="marchantia", taxonB="pisum", stringsAsFactors=FALSE)
 	\dontrun{
 	phy.nprs <- r8s.phylo(phy=phy, calibrations=calibrations, base="nprs_file", ez.run="NPRS")


### PR DESCRIPTION
As mentioned in a previous issue (https://github.com/mwpennell/geiger-v2/issues/20), geiger has several lines where it uses max(branching.times(tree)) to get a root-to-tip tree depth, including in `fitContinuous` with the EB model. For non-ultrametric trees, the value returned by this operation can be nonsense, or even negative. I have replaced those instances with max(node.depth.edgelength(tree)), which gives an identical answer for ultrametric trees, and the expected max tree depth for non-ultrametric trees.

I also made a number of small changes to get Travis CI to test the build, and it passes satisfactorily.