### PR TITLE
treePL now an option for congruify.phylo()

### DIFF
--- a/R/congruify.R
+++ b/R/congruify.R
@@ -114,7 +114,7 @@ congruify.phylo=function(reference, target, taxonomy=NULL, tol=0, scale=c(NA, "P
 			phy$hash=c(rep("", Ntip(phy)), phy$node.label)
 			phy$hash[phy$hash==""]=NA
 		} else if(method=="treePL") {
-			phy=treepl.phylo(scion, calibration, base=".tmp_PATHd8", rm=FALSE)
+			phy=treePL.phylo(scion, calibration, base=".tmp_treePL", rm=FALSE)
 			phy$hash=c(rep("", Ntip(phy)), phy$node.label)
 			phy$hash[phy$hash==""]=NA
 		} else if(method=="NA"){
@@ -165,7 +165,7 @@ congruify.phylo=function(reference, target, taxonomy=NULL, tol=0, scale=c(NA, "P
 ## END CONGRUIFICATION FUNCTIONS ##
 
 
-write.treePL=function(phy, calibrations, nsites, min=0.0001, base="", opts=list(smooth=100, nthreads=8, optad=0, opt=1, cvstart=1000, cviter=3, cvend=0.1, thorough=TRUE)){
+write.treePL=function(phy, calibrations, nsites=10000, min=0.0001, base="", opts=list(smooth=100, nthreads=8, optad=0, opt=1, cvstart=1000, cviter=3, cvend=0.1, thorough=TRUE)){
 #	calibrations: dataframe with minimally 'MRCA' 'MaxAge' 'MinAge' 'taxonA' and 'taxonB' from .build_calibrations
 #	MRCA							MaxAge     MinAge                                  taxonA                                  taxonB
 #	c65bacdf65aa29635bec90f3f0447c6e 352.234677 352.234677                          Inga_chartacea             Encephalartos_umbeluziensis
@@ -397,21 +397,19 @@ PATHd8.phylo=function(phy, calibrations=NULL, base="", rm=TRUE){
 treePL.phylo=function(phy, calibrations=NULL, base="", rm=TRUE){
 	phy$node.label=NULL
 	if(!is.null(calibrations)){
-		infile=write.treePL(phy, calibrations, base)
+		infile=write.treePL(phy=phy, calibrations=calibrations, base=base)
 	} else {
 		infile=paste(base, "infile", sep=".")
 		write.tree(phy, infile)
 	}
-	smooth.file=paste(base, "smoothed.tre", sep=".")
-	parsed.outfile=paste(base, "treePL.out", sep=".")
+	smooth.file=paste(base, "dated.tre", sep=".")
 	outfile=paste(base, "treePL.orig.out", sep=".")
 	if(file.exists(outfile)) unlink(outfile)
 	if(!system("which treePL", ignore.stdout=TRUE)==0) stop("Install 'treePL' before proceeding.")
-	system(paste("treePL -n", infile, "-pn >", outfile, sep=" "))
-	system(paste("grep \"tree\" ", outfile, ">", parsed.outfile, sep=" "))
-	smoothed=read.tree(parsed.outfile)
+	system(paste("treePL ", infile, " >", outfile, sep=" "))
+	#system(paste("grep \"tree\" ", outfile, ">", parsed.outfile, sep=" "))
+	smoothed=read.tree(smooth.file)
 	if(rm & base=="") {
-		unlink(parsed.outfile)
 		unlink(smooth.file)
 		unlink(outfile)
 		unlink(infile)

--- a/man/congruify.phylo.Rd
+++ b/man/congruify.phylo.Rd
@@ -7,7 +7,7 @@ ultrametricization of trees from a supplied timetree}
 \description{
 automagically generating secondary calibrations}
 \usage{
-congruify.phylo(reference, target, taxonomy = NULL, tol = 0, scale=c(NA, "PATHd8"),
+congruify.phylo(reference, target, taxonomy = NULL, tol = 0, scale=c(NA, "PATHd8", "treePL"),
     ncores=NULL)
 }
 %- maybe also 'usage' for other objects documented here.
@@ -16,17 +16,20 @@ congruify.phylo(reference, target, taxonomy = NULL, tol = 0, scale=c(NA, "PATHd8
   \item{target}{a phylogram that is sought to be ultrametricized based on the \code{reference} phylogeny}
   \item{taxonomy}{a linkage table between tips of the phylogeny and clades represented in the tree; rownames of 'taxonomy' should be tips found in the phylogeny}
   \item{tol}{branching time in \code{reference} above which secondary constraints will be applied to \code{target}}
-  \item{scale}{either \code{NA} or \code{"PATHd8"} (if \code{PATHd8} is available in the R \code{PATH})}
+  \item{scale}{\code{NA}, \code{"PATHd8"} or \code{"treePL"} (if \code{PATHd8} or \code{"treePL"} are available in the R \code{PATH})}
   \item{ncores}{number of cores to be used}
 }
 \details{
-	This function uses the \code{reference} to inform secondary calibrations in the \code{target}. The primary output is a table of 'congruent' nodes between the \code{reference} 
-	and \code{target} with associated dates extracted from corresponding nodes in the \code{reference}.  
-	
-	If multiple trees are supplied as the \code{reference}, a 'congruification' table is generated for each.  
-	
-	If \code{scale="PATHd8"}, the \code{target} will be smoothed by \code{PATHd8} using the "d8 calculation" (see \url{http://www2.math.su.se/PATHd8/PATHd8manual.pdf}). 
+	This function uses the \code{reference} to inform secondary calibrations in the \code{target}. The primary output is a table of 'congruent' nodes between the \code{reference}
+	and \code{target} with associated dates extracted from corresponding nodes in the \code{reference}.
+
+	If multiple trees are supplied as the \code{reference}, a 'congruification' table is generated for each.
+
+	If \code{scale="PATHd8"}, the \code{target} will be smoothed by \code{PATHd8} using the "d8 calculation" (see \url{http://www2.math.su.se/PATHd8/PATHd8manual.pdf}).
 	This scaling method requires that \code{PATHd8} is available on the user's \code{PATH} variable that can be accessed by \code{\link[base]{Sys.getenv}("PATH")}.
+
+  If \code{scale="treePL"}, the \code{target} will be smoothed by \code{treePL}.
+  This scaling method requires that \code{treePL} is available on the user's \code{PATH} variable that can be accessed by \code{\link[base]{Sys.getenv}("PATH")}.
 }
 
 \references{
@@ -54,4 +57,3 @@ cat("\n\n\n*** If 'PATHd8' is installed ***, execute the following:
 % R documentation directory.
 \keyword{graphs}
 \keyword{manip}
-


### PR DESCRIPTION
Updated help file and the R functionality. Example of use:

```
library(geiger)
sal=get(data(caudata))
res.treePL=congruify.phylo(sal$fam, sal$phy, sal$tax, tol=0, scale="treePL", ncores=1)
res.pathd8=congruify.phylo(sal$fam, sal$phy, sal$tax, tol=0, scale="PATHd8", ncores=1)
min(branching.times(res.treePL$phy))
min(branching.times(res.pathd8$phy))
```

Having this accepted, and having geiger pushed back to CRAN, would help with both the datelife project and other stuff being worked on in the lab. ("install geiger from cran" is easier than "install geiger from its github repo" which is easier than "install geiger from Brian's fork of geiger's github repo").