### PR TITLE
testing phylo class with 'is.phylo' instead of '=='

### DIFF
--- a/R/congruify.R
+++ b/R/congruify.R
@@ -132,7 +132,7 @@ congruify.phylo=function(reference, target, taxonomy=NULL, tol=0, scale=c(NA, "P
 	classification=taxonomy
 	unfurl=FALSE
 
-	if(class(stock)=="phylo") {
+	if(is.phylo(stock)) {
 		stock=list(stock)
 		unfurl=TRUE
 	}


### PR DESCRIPTION
I am running congruify on phylo objects that are also another class.
Using `is.phylo(stock)` instead of `class(stock) == "phylo"` allows testing data objects with multiple classes.